### PR TITLE
feat: 회원 수정 및 탈퇴 기능 구현 및 단위 테스트 추가 (#23)

### DIFF
--- a/src/main/java/com/loco/loco_api/common/dto/user/request/UserUpdateRequest.java
+++ b/src/main/java/com/loco/loco_api/common/dto/user/request/UserUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.loco.loco_api.common.dto.user.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "회원 수정 요청 DTO")
+public record UserUpdateRequest(
+        @Schema(description = "닉네임", example = "dev_ian")
+        String nickname,
+
+        @Schema(description = "프로필 이미지 URL", example = "https://cdn.example.com/img.png")
+        String profileImageUrl
+) {}

--- a/src/main/java/com/loco/loco_api/common/dto/user/response/UserDeleteResponse.java
+++ b/src/main/java/com/loco/loco_api/common/dto/user/response/UserDeleteResponse.java
@@ -1,0 +1,10 @@
+package com.loco.loco_api.common.dto.user.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "회원 탈퇴 응답 DTO")
+public record UserDeleteResponse(
+        @Schema(description = "탈퇴 완료 메시지", example = "회원 탈퇴가 완료되었습니다.")
+        String message
+) {}
+

--- a/src/main/java/com/loco/loco_api/common/exception/ErrorCode.java
+++ b/src/main/java/com/loco/loco_api/common/exception/ErrorCode.java
@@ -71,7 +71,8 @@ public enum ErrorCode {
   // 서버 오류
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5000, "서버 내부 오류입니다."),
   DATABASE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5000, "데이터베이스 오류가 발생했습니다."),
-  EXTERNAL_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5000, "외부 API 호출 중 오류가 발생했습니다.");
+  EXTERNAL_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5000, "외부 API 호출 중 오류가 발생했습니다."),
+  USER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, 5000, "이미 탈퇴한 회원입니다."),;
 
   private final HttpStatus httpStatus;
   private final int code;           // 시스템 내부 관리용 숫자 코드

--- a/src/main/java/com/loco/loco_api/controller/UserController.java
+++ b/src/main/java/com/loco/loco_api/controller/UserController.java
@@ -1,5 +1,7 @@
 package com.loco.loco_api.controller;
 
+import com.loco.loco_api.common.dto.user.request.UserUpdateRequest;
+import com.loco.loco_api.common.dto.user.response.UserDeleteResponse;
 import com.loco.loco_api.common.dto.user.response.UserResponse;
 import com.loco.loco_api.common.response.ApiResponse;
 import com.loco.loco_api.domain.user.UserEntity;
@@ -7,9 +9,7 @@ import com.loco.loco_api.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -33,5 +33,29 @@ public class UserController {
     );
 
     return ApiResponse.success(response);
+  }
+
+  @PutMapping
+  public ApiResponse<UserResponse> updateUser(
+          @AuthenticationPrincipal Jwt jwt,
+          @RequestBody UserUpdateRequest request
+  ) {
+    UserEntity updatedUser = userService.updateUser(jwt, request);
+
+    UserResponse response = new UserResponse(
+            updatedUser.getId().toString(),
+            updatedUser.getNickname(),
+            updatedUser.getProfileImageUrl(),
+            List.of("ROLE_USER")
+    );
+
+    return ApiResponse.success(response);
+  }
+
+  @DeleteMapping
+  public ApiResponse<UserDeleteResponse> deleteUser(@AuthenticationPrincipal Jwt jwt) {
+    userService.deleteUser(jwt);
+
+    return ApiResponse.success(new UserDeleteResponse("회원 탈퇴가 완료되었습니다."));
   }
 }

--- a/src/main/java/com/loco/loco_api/domain/user/UserEntity.java
+++ b/src/main/java/com/loco/loco_api/domain/user/UserEntity.java
@@ -53,4 +53,10 @@ public class UserEntity extends UserAuditableEntity {
   public boolean isActive() {
     return this.deletedAt == null;
   }
+
+  /** 유저 정보 수정 */
+  public void updateProfile(String nickname, String profileImageUrl) {
+    this.nickname = nickname;
+    this.profileImageUrl = profileImageUrl;
+  }
 }

--- a/src/test/java/com/loco/loco_api/controller/user/UserControllerTest.java
+++ b/src/test/java/com/loco/loco_api/controller/user/UserControllerTest.java
@@ -1,4 +1,4 @@
-package com.loco.loco_api.controller;
+package com.loco.loco_api.controller.user;
 
 import com.loco.loco_api.domain.user.UserEntity;
 import com.loco.loco_api.repository.UserRepository;
@@ -45,5 +45,6 @@ class UserIntegrationTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.data.name").value("이안"));
   }
+
 }
 

--- a/src/test/java/com/loco/loco_api/controller/user/UserServiceTest.java
+++ b/src/test/java/com/loco/loco_api/controller/user/UserServiceTest.java
@@ -1,0 +1,119 @@
+package com.loco.loco_api.controller.user;
+
+import com.loco.loco_api.common.dto.user.request.UserUpdateRequest;
+import com.loco.loco_api.common.exception.CustomException;
+import com.loco.loco_api.common.exception.ErrorCode;
+import com.loco.loco_api.domain.user.UserEntity;
+import com.loco.loco_api.repository.UserRepository;
+import com.loco.loco_api.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+  @Mock
+  private UserRepository userRepository;
+
+  @InjectMocks
+  private UserService userService;
+
+  private Jwt jwt;
+  private UserEntity activeUser;
+
+  @BeforeEach
+  void setUp() {
+    // jwt mock
+    jwt = mock(Jwt.class);
+    when(jwt.getSubject()).thenReturn("google_12345");
+
+    // 사용자 엔티티 (탈퇴하지 않은 상태)
+    activeUser = UserEntity.builder()
+            .id(1L)
+            .nickname("oldNick")
+            .profileImageUrl("http://img.old.png")
+            .deletedAt(null)
+            .build();
+  }
+
+  @Test
+  void updateUser_success() {
+    // given
+    UserUpdateRequest request = new UserUpdateRequest("newNick", "http://img.new.png");
+    when(userRepository.findByProviderAndOauthId(anyString(), anyString()))
+            .thenReturn(Optional.of(activeUser));
+    when(userRepository.save(any(UserEntity.class))).thenReturn(activeUser);
+
+    // when
+    UserEntity result = userService.updateUser(jwt, request);
+
+    // then
+    assertThat(result.getNickname()).isEqualTo("newNick");
+    assertThat(result.getProfileImageUrl()).isEqualTo("http://img.new.png");
+  }
+
+  @Test
+  void updateUser_throw_whenAlreadyDeleted() {
+    // given
+    activeUser.delete(); // deletedAt 세팅
+    when(userRepository.findByProviderAndOauthId(anyString(), anyString()))
+            .thenReturn(Optional.of(activeUser));
+
+    // when & then
+    assertThatThrownBy(() ->
+            userService.updateUser(jwt, new UserUpdateRequest("nick", "http://img.png"))
+    ).isInstanceOf(CustomException.class)
+            .hasMessage(ErrorCode.USER_ALREADY_DELETED.getMessage());
+  }
+
+  @Test
+  void updateUser_throw_whenInvalidNickname() {
+    // given
+    when(userRepository.findByProviderAndOauthId(anyString(), anyString()))
+            .thenReturn(Optional.of(activeUser));
+
+    // when & then
+    assertThatThrownBy(() ->
+            userService.updateUser(jwt, new UserUpdateRequest("   ", "http://img.png"))
+    ).isInstanceOf(CustomException.class)
+            .hasMessage(ErrorCode.INVALID_INPUT_VALUE.getMessage());
+  }
+
+  @Test
+  void deleteUser_success() {
+    // given
+    when(userRepository.findByProviderAndOauthId(anyString(), anyString()))
+            .thenReturn(Optional.of(activeUser));
+
+    // when
+    userService.deleteUser(jwt);
+
+    // then
+    assertThat(activeUser.getDeletedAt()).isNotNull();
+    verify(userRepository, times(1)).save(activeUser);
+  }
+
+  @Test
+  void deleteUser_throw_whenAlreadyDeleted() {
+    // given
+    activeUser.delete();
+    when(userRepository.findByProviderAndOauthId(anyString(), anyString()))
+            .thenReturn(Optional.of(activeUser));
+
+    // when & then
+    assertThatThrownBy(() -> userService.deleteUser(jwt))
+            .isInstanceOf(CustomException.class)
+            .hasMessage(ErrorCode.USER_ALREADY_DELETED.getMessage());
+  }
+}


### PR DESCRIPTION
- UserController에 PUT /api/v1/users, DELETE /api/v1/users 엔드포인트 추가
- UserService에 updateUser, deleteUser 로직 및 예외 처리 적용
  - 탈퇴 회원 수정/삭제 방지
  - 닉네임, 프로필 URL 입력값 유효성 검증
- CustomException + ErrorCode 기반 예외 연동
- JUnit 단위 테스트 작성 (성공/실패/예외 케이스 검증)

## 📌 개요
PR에 대한 간단한 요약을 작성해주세요.

> 예시: 로그인 기능에 필요한 컨트롤러, 서비스, JWT 발급 로직을 구현했습니다.

## 🔨 작업 내용
구현한 작업 목록을 체크리스트로 작성해주세요.

- [x] LoginController 생성
- [x] AuthService 로직 작성
- [x] JWT 발급 유틸 추가
- [x] 테스트 코드 작성

## 🔗 관련 이슈
Closes #42

> 해당 PR이 병합되면 이슈 #42가 자동으로 종료됩니다.

## 🧪 테스트 방법
어떻게 테스트했는지 또는 확인 방법을 작성해주세요.

> 예시: Postman으로 `/api/auth/login` 테스트, 정상 응답 확인

## 💬 참고 사항
리뷰어에게 전하고 싶은 말, 주의사항 등을 작성해주세요.

> 예시: 리팩토링이 필요할 수도 있어 구조에 대해 코멘트 부탁드립니다.
